### PR TITLE
Projekt 5stars+

### DIFF
--- a/Frontend/MoptPaymentPayone/Controllers/Backend/FcPayone.php
+++ b/Frontend/MoptPaymentPayone/Controllers/Backend/FcPayone.php
@@ -53,7 +53,7 @@ class Shopware_Controllers_Backend_FcPayone extends Enlight_Controller_Action
         $data = $this->get('MoptPayoneMain')->getPayoneConfig(0, true);
         $params = $this->get('MoptPayoneMain')->getParamBuilder()->buildAuthorize("mopt_payone_creditcard");
 
-        $filename = Shopware()->Application()->Kernel()->getRootDir() . '/engine/Shopware/Plugins/Local/Frontend/MoptPaymentPayone/dashboardconfig.txt';
+        $filename = __DIR__ . '/../../dashboardconfig.txt';
         
         $config = file_get_contents($filename);
         $aConfig = json_decode($config);

--- a/Frontend/MoptPaymentPayone/Views/backend/fc_payone/apilog.tpl
+++ b/Frontend/MoptPaymentPayone/Views/backend/fc_payone/apilog.tpl
@@ -69,7 +69,7 @@
         }
 
         function modeDetailsFormatter(value) {
-            if (value == 'false')
+            if (value === false)
             {
                 return 'Test';
             } else {

--- a/Frontend/MoptPaymentPayone/Views/backend/fc_payone/transactionlog.tpl
+++ b/Frontend/MoptPaymentPayone/Views/backend/fc_payone/transactionlog.tpl
@@ -63,7 +63,7 @@
         }
 
         function modeDetailsFormatter(value) {
-            if (value == 'false')
+            if (value === false)
             {
                 return 'Test';
             } else {


### PR DESCRIPTION
Apilog und transaktionslogs: falsche Darstellung von Live und Testmodus