### PR TITLE
Fixed a load of namespace and type hinting errors

### DIFF
--- a/Frontend/MoptPaymentPayone/Subscribers/AddressCheck.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/AddressCheck.php
@@ -20,7 +20,7 @@ class AddressCheck implements SubscriberInterface
      * 
      * @param \Shopware\Components\DependencyInjection\Container $container
      */
-    public function __construct(Container $container)
+    public function __construct(\Shopware\Components\DependencyInjection\Container $container)
     {
         $this->container = $container;
     }
@@ -61,10 +61,10 @@ class AddressCheck implements SubscriberInterface
   /**
    * prepare payone risk checks
    * 
-   * @param Enlight_Hook_HookArgs $arguments
+   * @param \Enlight_Hook_HookArgs $arguments
    * @return boolean
    */
-  public function sAdmin__sManageRisks__before(Enlight_Hook_HookArgs $arguments)
+  public function sAdmin__sManageRisks__before(\Enlight_Hook_HookArgs $arguments)
   {
       Shopware()->Session()->moptRiskCheckPaymentId = $arguments->get('paymentID');
   }
@@ -72,10 +72,10 @@ class AddressCheck implements SubscriberInterface
   /**
    * clean up payone risk checks
    * 
-   * @param Enlight_Hook_HookArgs $arguments
+   * @param \Enlight_Hook_HookArgs $arguments
    * @return boolean
    */
-  public function sAdmin__sManageRisks__after(Enlight_Hook_HookArgs $arguments)
+  public function sAdmin__sManageRisks__after(\Enlight_Hook_HookArgs $arguments)
   {
       unset(Shopware()->Session()->moptRiskCheckPaymentId);
   }
@@ -85,9 +85,9 @@ class AddressCheck implements SubscriberInterface
      * returns true if risk condition is fulfilled
      * arguments: $rule, $user, $basket, $value
      * 
-     * @param \Shopware\Plugins\MoptPaymentPayone\Subscribers\Enlight_Hook_HookArgs $arguments
+     * @param \Enlight_Hook_HookArgs $arguments
      */
-    public function sAdmin__executeRiskRule(Enlight_Hook_HookArgs $arguments)
+    public function sAdmin__executeRiskRule(\Enlight_Hook_HookArgs $arguments)
     {
         $rule = $arguments->get('rule');
         
@@ -379,10 +379,10 @@ class AddressCheck implements SubscriberInterface
   /**
    * perform risk checks
    * 
-   * @param Enlight_Hook_HookArgs $arguments
+   * @param \Enlight_Hook_HookArgs $arguments
    * @return type
    */
-  public function onConfirmAction(Enlight_Hook_HookArgs $arguments)
+  public function onConfirmAction(\Enlight_Hook_HookArgs $arguments)
   {
     $subject = $arguments->getSubject();
     $moptPayoneMain = $this->container->get('MoptPayoneMain');
@@ -527,9 +527,9 @@ class AddressCheck implements SubscriberInterface
   /**
    * billingaddress addresscheck
    * 
-   * @param Enlight_Hook_HookArgs $arguments 
+   * @param \Enlight_Event_EventArgs $arguments
    */
-  public function onValidateStep2(Enlight_Hook_HookArgs $arguments)
+  public function onValidateStep2(\Enlight_Event_EventArgs $arguments)
   {
     $ret = $arguments->getReturn();
 
@@ -694,9 +694,9 @@ class AddressCheck implements SubscriberInterface
   /**
    * save addresscheck result
    *
-   * @param Enlight_Hook_HookArgs $arguments 
+   * @param \Enlight_Hook_HookArgs $arguments
    */
-  public function onSaveRegister(Enlight_Hook_HookArgs $arguments)
+  public function onSaveRegister(\Enlight_Hook_HookArgs $arguments)
   {
       $this->onUpdateBilling($arguments);
       $this->onUpdateShipping($arguments);
@@ -705,9 +705,9 @@ class AddressCheck implements SubscriberInterface
   /**
    * save addresscheck result
    *
-   * @param Enlight_Hook_HookArgs $arguments 
+   * @param \Enlight_Hook_HookArgs $arguments
    */
-  public function onUpdateBilling(Enlight_Hook_HookArgs $arguments)
+  public function onUpdateBilling(\Enlight_Hook_HookArgs $arguments)
   {
     $session = Shopware()->Session();
 
@@ -745,9 +745,9 @@ class AddressCheck implements SubscriberInterface
    * 
    * shipmentaddress addresscheck
    * 
-   * @param Enlight_Hook_HookArgs $arguments 
+   * @param \Enlight_Event_EventArgs $arguments
    */
-  public function onValidateStep2ShippingAddress(Enlight_Hook_HookArgs $arguments)
+  public function onValidateStep2ShippingAddress(\Enlight_Event_EventArgs $arguments)
   {
     $ret = $arguments->getReturn();
 
@@ -902,9 +902,9 @@ class AddressCheck implements SubscriberInterface
   /**
    * save addresscheck result
    *
-   * @param Enlight_Hook_HookArgs $arguments 
+   * @param \Enlight_Hook_HookArgs $arguments
    */
-  public function onUpdateShipping(Enlight_Hook_HookArgs $arguments)
+  public function onUpdateShipping(\Enlight_Hook_HookArgs $arguments)
   {
     $session = Shopware()->Session();
 
@@ -939,7 +939,7 @@ class AddressCheck implements SubscriberInterface
   }
   
   
-  public function onUpdatePayment(Enlight_Hook_HookArgs $arguments)
+  public function onUpdatePayment(\Enlight_Hook_HookArgs $arguments)
   {
     $session = Shopware()->Session();
 

--- a/Frontend/MoptPaymentPayone/Subscribers/BackendOrder.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/BackendOrder.php
@@ -20,7 +20,7 @@ class BackendOrder implements SubscriberInterface
      * 
      * @param \Shopware\Components\DependencyInjection\Container $container
      */
-    public function __construct(Container $container)
+    public function __construct(\Shopware\Components\DependencyInjection\Container $container)
     {
         $this->container = $container;
     }
@@ -40,7 +40,7 @@ class BackendOrder implements SubscriberInterface
         );
     }
     
-    public function moptExtendController_Backend_Order(Enlight_Event_EventArgs $args)
+    public function moptExtendController_Backend_Order(\Enlight_Controller_ActionEventArgs $args)
     {
         $view = $args->getSubject()->View();
         $view->extendsTemplate('backend/mopt_payone_order/controller/detail.js');
@@ -53,9 +53,9 @@ class BackendOrder implements SubscriberInterface
     * add attribute data to detail-data
     * @parent fnc head: protected function getList($filter, $sort, $offset, $limit)
     * 
-    * @param Enlight_Event_EventArgs $args
+    * @param \Enlight_Controller_ActionEventArgs $args
     */
-    public function Order__getList__after(Enlight_Event_EventArgs $args)
+    public function Order__getList__after(\Enlight_Controller_ActionEventArgs $args)
     {
       $return = $args->getReturn();
       $helper = $this->container->get('MoptPayoneMain')->getHelper();

--- a/Frontend/MoptPaymentPayone/Subscribers/BackendPayment.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/BackendPayment.php
@@ -19,7 +19,7 @@ class BackendPayment implements SubscriberInterface
      * 
      * @param \Shopware\Components\DependencyInjection\Container $container
      */
-    public function __construct(Container $container)
+    public function __construct(\Shopware\Components\DependencyInjection\Container $container)
     {
         $this->container = $container;
     }
@@ -37,7 +37,7 @@ class BackendPayment implements SubscriberInterface
         );
     }
 
-    public function moptExtendController_Backend_Payment(Enlight_Event_EventArgs $args)
+    public function moptExtendController_Backend_Payment(\Enlight_Controller_ActionEventArgs $args)
     {
         $view = $args->getSubject()->View();
         $view->extendsTemplate('backend/mopt_payone_payment/controller/payment.js');

--- a/Frontend/MoptPaymentPayone/Subscribers/BackendRiskManagement.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/BackendRiskManagement.php
@@ -19,7 +19,7 @@ class BackendRiskManagement implements SubscriberInterface
      * 
      * @param \Shopware\Components\DependencyInjection\Container $container
      */
-    public function __construct(Container $container)
+    public function __construct(\Shopware\Components\DependencyInjection\Container $container)
     {
         $this->container = $container;
     }
@@ -37,7 +37,7 @@ class BackendRiskManagement implements SubscriberInterface
         );
     }
 
-    public function onBackendRiskManagementPostDispatch(Enlight_Event_EventArgs $args)
+    public function onBackendRiskManagementPostDispatch(\Enlight_Controller_ActionEventArgs $args)
     {
         $view = $args->getSubject()->View();
         $view->extendsTemplate('backend/mopt_risk_management/controller/main.js');

--- a/Frontend/MoptPaymentPayone/Subscribers/Document.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/Document.php
@@ -26,7 +26,7 @@ class Document implements SubscriberInterface
      * 
      * @param \Shopware\Components\DependencyInjection\Container $container
      */
-    public function __construct(Container $container, $path)
+    public function __construct(\Shopware\Components\DependencyInjection\Container $container, $path)
     {
         $this->container = $container;
         $this->path = $path;
@@ -48,9 +48,9 @@ class Document implements SubscriberInterface
     /**
      * add payone clearing data to document
      * 
-     * @param \Shopware\Plugins\MoptPaymentPayone\Subscribers\Enlight_Hook_HookArgs $args
+     * @param \Enlight_Hook_HookArgs $args
      */
-    public function onBeforeRenderDocument(Enlight_Hook_HookArgs $args)
+    public function onBeforeRenderDocument(\Enlight_Hook_HookArgs $args)
     {
         $document = $args->getSubject();
 

--- a/Frontend/MoptPaymentPayone/Subscribers/EMail.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/EMail.php
@@ -22,7 +22,7 @@ class EMail implements SubscriberInterface
      * 
      * @param \Shopware\Components\DependencyInjection\Container $container
      */
-    public function __construct(Container $container)
+    public function __construct(\Shopware\Components\DependencyInjection\Container $container)
     {
         $this->container = $container;
     }
@@ -42,10 +42,10 @@ class EMail implements SubscriberInterface
     /**
      * add clearing data to email variables
      * 
-     * @param \Shopware\Plugins\MoptPaymentPayone\Subscribers\Enlight_Hook_HookArgs $args
+     * @param \Enlight_Event_EventArgs $args
      * @return array
      */
-    public function onSendMailFilterVariablesFilter(Enlight_Hook_HookArgs $args)
+    public function onSendMailFilterVariablesFilter(\Enlight_Event_EventArgs $args)
     {
         $variables = $args->getReturn();
         $session = Shopware()->Session();

--- a/Frontend/MoptPaymentPayone/Subscribers/FrontendAccount.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/FrontendAccount.php
@@ -19,7 +19,7 @@ class FrontendAccount implements SubscriberInterface
      * 
      * @param \Shopware\Components\DependencyInjection\Container $container
      */
-    public function __construct(Container $container)
+    public function __construct(\Shopware\Components\DependencyInjection\Container $container)
     {
         $this->container = $container;
     }
@@ -38,11 +38,11 @@ class FrontendAccount implements SubscriberInterface
     }
 
     /**
-     * assign saved paymend data to view
+     * assign saved payment data to view
      * 
-     * @param Enlight_Hook_HookArgs $arguments
+     * @param \Enlight_Hook_HookArgs $arguments
      */
-    public function onPaymentAction(Enlight_Hook_HookArgs $arguments)
+    public function onPaymentAction(\Enlight_Hook_HookArgs $arguments)
     {
         $subject = $arguments->getSubject();
         $userId = Shopware()->Session()->sUserId;

--- a/Frontend/MoptPaymentPayone/Subscribers/FrontendCheckout.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/FrontendCheckout.php
@@ -19,7 +19,7 @@ class FrontendCheckout implements SubscriberInterface
      * 
      * @param \Shopware\Components\DependencyInjection\Container $container
      */
-    public function __construct(Container $container)
+    public function __construct(\Shopware\Components\DependencyInjection\Container $container)
     {
         $this->container = $container;
     }
@@ -42,10 +42,10 @@ class FrontendCheckout implements SubscriberInterface
     /**
      * assign saved payment data to view
      * 
-     * @param Enlight_Hook_HookArgs $arguments
+     * @param \Enlight_Hook_HookArgs $arguments
      * @return type
      */
-    public function onGetSelectedPayment(Enlight_Hook_HookArgs $arguments)
+    public function onGetSelectedPayment(\Enlight_Hook_HookArgs $arguments)
     {
         $action = Shopware()->Modules()->Admin()->sSYSTEM->_GET['action'];
         $sTargetAction = Shopware()->Modules()->Admin()->sSYSTEM->_GET['sTargetAction'];
@@ -84,7 +84,7 @@ class FrontendCheckout implements SubscriberInterface
         $arguments->setReturn($ret);
     }
 
-    public function moptExtendController_Frontend_Checkout(Enlight_Event_EventArgs $args)
+    public function moptExtendController_Frontend_Checkout(\Enlight_Controller_ActionEventArgs $args)
     {
         $subject = $args->getSubject();
         $view = $subject->View();

--- a/Frontend/MoptPaymentPayone/Subscribers/FrontendPostDispatch.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/FrontendPostDispatch.php
@@ -26,7 +26,7 @@ class FrontendPostDispatch implements SubscriberInterface
      * 
      * @param \Shopware\Components\DependencyInjection\Container $container
      */
-    public function __construct(Container $container, $path)
+    public function __construct(\Shopware\Components\DependencyInjection\Container $container, $path)
     {
         $this->container = $container;
         $this->path = $path;
@@ -48,9 +48,9 @@ class FrontendPostDispatch implements SubscriberInterface
     /**
      * choose correct tpl folder
      * 
-     * @param Enlight_Event_EventArgs $args
+     * @param \Enlight_Controller_ActionEventArgs $args
      */
-    public function onPostDispatchBackend(Enlight_Event_EventArgs $args)
+    public function onPostDispatchBackend(\Enlight_Controller_ActionEventArgs $args)
     {
         $request = $args->getSubject()->Request();
         $response = $args->getSubject()->Response();
@@ -64,9 +64,9 @@ class FrontendPostDispatch implements SubscriberInterface
     /**
      * choose correct tpl folder and extend shopware templates
      * 
-     * @param Enlight_Event_EventArgs $args
+     * @param \Enlight_Controller_ActionEventArgs $args
      */
-    public function onPostDispatchFrontend(Enlight_Event_EventArgs $args)
+    public function onPostDispatchFrontend(\Enlight_Controller_ActionEventArgs $args)
     {
         $request = $args->getSubject()->Request();
         $response = $args->getSubject()->Response();

--- a/Frontend/MoptPaymentPayone/Subscribers/Payment.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/Payment.php
@@ -19,7 +19,7 @@ class Payment implements SubscriberInterface
      * 
      * @param \Shopware\Components\DependencyInjection\Container $container
      */
-    public function __construct(Container $container)
+    public function __construct(\Shopware\Components\DependencyInjection\Container $container)
     {
         $this->container = $container;
     }
@@ -46,9 +46,9 @@ class Payment implements SubscriberInterface
     /**
      * consumerscore check after choice if payment method
      * 
-     * @param Enlight_Hook_HookArgs $arguments 
+     * @param \Enlight_Hook_HookArgs $arguments
      */
-    public function onValidateStep3(Enlight_Hook_HookArgs $arguments)
+    public function onValidateStep3(\Enlight_Hook_HookArgs $arguments)
     {
         $returnValues = $arguments->getReturn();
         if (!empty($returnValues['sErrorMessages'])) {
@@ -217,9 +217,9 @@ class Payment implements SubscriberInterface
     /**
      * group creditcard payments
      * 
-     * @param Enlight_Hook_HookArgs $arguments 
+     * @param \Enlight_Hook_HookArgs $arguments
      */
-    public function onGetPaymentMeans(Enlight_Hook_HookArgs $arguments)
+    public function onGetPaymentMeans(\Enlight_Hook_HookArgs $arguments)
     {
         $dontGroupCreditCardActions = array('addArticle', 'cart', 'changeQuantity', 'confirm');
         $request = Shopware()->Front()->Request();
@@ -252,9 +252,9 @@ class Payment implements SubscriberInterface
     /**
      * special handling for grouped credit cards to calculate correct shipment costs
      * 
-     * @param Enlight_Hook_HookArgs $arguments 
+     * @param \Enlight_Hook_HookArgs $arguments
      */
-    public function onGetDispatchBasket(Enlight_Hook_HookArgs $arguments)
+    public function onGetDispatchBasket(\Enlight_Hook_HookArgs $arguments)
     {
         $returnValues = $arguments->getReturn();
         $paymenthelper = $this->container->get('MoptPayoneMain')->getPaymentHelper();
@@ -288,10 +288,10 @@ class Payment implements SubscriberInterface
     /**
      * group credit cards for payment form
      * 
-     * @param Enlight_Hook_HookArgs $arguments
+     * @param \Enlight_Hook_HookArgs $arguments
      * @return type
      */
-    public function onShippingPaymentAction(Enlight_Hook_HookArgs $arguments)
+    public function onShippingPaymentAction(\Enlight_Hook_HookArgs $arguments)
     {
         $subject = $arguments->getSubject();
         $moptPayoneMain = $this->container->get('MoptPayoneMain');

--- a/Frontend/MoptPaymentPayone/Subscribers/Resource.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/Resource.php
@@ -24,10 +24,10 @@ class Resource implements SubscriberInterface
   /**
    * Creates and returns the payone builder for an event.
    *
-   * @param Enlight_Event_EventArgs $args
+   * @param \Enlight_Event_EventArgs $args
    * @return \Shopware_Components_Payone_Builder
    */
-  public function onInitResourcePayoneBuilder(Enlight_Event_EventArgs $args)
+  public function onInitResourcePayoneBuilder(\Enlight_Event_EventArgs $args)
   {
     $payoneConfig = new \Payone_Config();
     $logger = array('Payone_Protocol_Logger_Log4php' => null);
@@ -45,10 +45,10 @@ class Resource implements SubscriberInterface
   /**
    * Creates and returns the payone builder for an event.
    *
-   * @param Enlight_Event_EventArgs $args
+   * @param \Enlight_Event_EventArgs $args
    * @return \Shopware_Components_Payone_Builder
    */
-  public function onInitResourcePayoneMain(Enlight_Event_EventArgs $args)
+  public function onInitResourcePayoneMain(\Enlight_Event_EventArgs $args)
   {
     $moptPayoneMain = \Mopt_PayoneMain::getInstance();
     return $moptPayoneMain;


### PR DESCRIPTION
This should fix a lot of errors identified using the standard Shopware phpunit test suites and enable merchants to use a CD workflow. However, backwards compatibility is not clear yet.

Changes and their test results in detail:
* Unmodified MoptPaymentPayone:
Tests: 988, Assertions: 5397, Errors: 94, Failures: 18, Skipped: 63.
* Added \Shopware\Components\DependencyInjection\ before every Container in Subscriber registration:
Tests: 988, Assertions: 5168, Errors: 97, Failures: 22, Skipped: 63.
* Changed Enlight_Event_EventArgs to \Enlight_Controller_ActionEventArgs
Tests: 1024, Assertions: 6093, Errors: 40, Failures: 20, Skipped: 27.
* Fixed Enlight_Event_EventArgs to \Enlight_Event_EventArgs in Resource.php
Tests: 1028, Assertions: 7082, Errors: 7, Failures: 17, Skipped: 23.
* Fixed Enlight_Hook_HookArgs to \Enlight_Hook_HookArgs
Tests: 1028, Assertions: 7216, Errors: 4, Failures: 14, Skipped: 23.
* Some \Enlight_Hook_HookArgs were actually \Enlight_Event_EventArgs
Tests: 1028, Assertions: 7287, Failures: 14, Skipped: 23.