### PR TITLE
Removed duplicate BackendOrder subscription (fixes TPI-1526)

### DIFF
--- a/Frontend/MoptPaymentPayone/Bootstrap.php
+++ b/Frontend/MoptPaymentPayone/Bootstrap.php
@@ -238,7 +238,6 @@ class Shopware_Plugins_Frontend_MoptPaymentPayone_Bootstrap extends Shopware_Com
             // Backend
             new \Shopware\Plugins\MoptPaymentPayone\Subscribers\BackendPayment($container),
             new \Shopware\Plugins\MoptPaymentPayone\Subscribers\BackendRiskManagement($container),
-            new \Shopware\Plugins\MoptPaymentPayone\Subscribers\BackendOrder($container),
             new \Shopware\Plugins\MoptPaymentPayone\Subscribers\BackendOrder($container)
         );
         foreach ($subscribers as $subscriber) {


### PR DESCRIPTION
The duplicate subscription created a problem that VAT was added twice when the price of a position in the order was changed in the backend.