### PR TITLE
save transaction id in own database table field

### DIFF
--- a/Frontend/MoptPaymentPayone/Bootstrap.php
+++ b/Frontend/MoptPaymentPayone/Bootstrap.php
@@ -537,6 +537,11 @@ class Shopware_Plugins_Frontend_MoptPaymentPayone_Bootstrap extends Shopware_Com
         $this->getInstallHelper()->checkAndUpdateCreditcardModelIframeExtension();
         
         $this->getInstallHelper()->checkAndUpdateConfigModelPayolutionInstallmentExtension();
+
+        // adding transaction id in log table
+        if (!$this->getInstallHelper()->payoneApiLogTransactionIdExist()) {
+            $this->getInstallHelper()->extendPayoneApiLogTransactionId();
+        }
     }
 
     /**

--- a/Frontend/MoptPaymentPayone/Components/Classes/PayoneInstallHelper.php
+++ b/Frontend/MoptPaymentPayone/Components/Classes/PayoneInstallHelper.php
@@ -1073,4 +1073,33 @@ class Mopt_PayoneInstallHelper
         }
     }
 
+    /**
+     * check if transaction id exist in api log table
+     * @return bool
+     */
+    public function payoneApiLogTransactionIdExist()
+    {
+        $DBConfig = Shopware()->Db()->getConfig();
+
+        $sql = "SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='s_plugin_mopt_payone_api_log'
+                AND TABLE_SCHEMA='" . $DBConfig['dbname'] . "'
+                AND COLUMN_NAME ='transaction_id';";
+        $result = Shopware()->Db()->query($sql);
+
+        if ($result->rowCount() === 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * adding new field to database
+     */
+    public function extendPayoneApiLogTransactionId()
+    {
+        $sql = "ALTER TABLE `s_plugin_mopt_payone_api_log` "
+            . "ADD COLUMN transaction_id VARCHAR(255);";
+        Shopware()->Db()->exec($sql);
+    }
 }

--- a/Frontend/MoptPaymentPayone/Components/Payone/Api/Response/Interface.php
+++ b/Frontend/MoptPaymentPayone/Components/Payone/Api/Response/Interface.php
@@ -97,4 +97,10 @@ interface Payone_Api_Response_Interface extends Payone_Protocol_Filter_Filterabl
 
     /** @param string $rawResponse */
     public function setRawResponse($rawResponse);
+
+    /**
+     * @param string $key
+     * @return string
+     */
+    public function getValue($key);
 }

--- a/Frontend/MoptPaymentPayone/Models/MoptPayoneApiLog/MoptPayoneApiLog.php
+++ b/Frontend/MoptPaymentPayone/Models/MoptPayoneApiLog/MoptPayoneApiLog.php
@@ -67,6 +67,12 @@ class MoptPayoneApiLog extends ModelEntity
    */
     private $responseDetails;
 
+    /**
+     * @var string $transactionId
+     * @ORM\Column(name="transaction_id", length=255, type="string", nullable=true)
+     */
+    private $transactionId;
+
   /**
    * @var \Doctrine\Common\Collections\ArrayCollection
    */
@@ -198,5 +204,21 @@ class MoptPayoneApiLog extends ModelEntity
     public function setResponseDetails($responseDetails)
     {
         $this->responseDetails = $responseDetails;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTransactionId()
+    {
+        return $this->transactionId;
+    }
+
+    /**
+     * @param string $transactionId
+     */
+    public function setTransactionId($transactionId)
+    {
+        $this->transactionId = $transactionId;
     }
 }

--- a/Frontend/MoptPaymentPayone/Models/MoptPayoneApiLog/Repository.php
+++ b/Frontend/MoptPaymentPayone/Models/MoptPayoneApiLog/Repository.php
@@ -46,6 +46,7 @@ class Repository extends ModelRepository implements \Payone_Api_Persistence_Inte
             $apiLog->setCreationDate(date('Y-m-d\TH:i:sP'));
             $apiLog->setRequestDetails($request->__toString());
             $apiLog->setResponseDetails($response->__toString());
+            $apiLog->setTransactionId($response->getValue('txid'));
         }
 
         Shopware()->Models()->persist($apiLog);


### PR DESCRIPTION
This change save transaction id in own database table field.

Sometimes it's necessary to search by transaction id, it's much easily and faster with an own field.