### PR TITLE
Refactor the subscriber Resource -> PayoneResource

### DIFF
--- a/Frontend/MoptPaymentPayone/Bootstrap.php
+++ b/Frontend/MoptPaymentPayone/Bootstrap.php
@@ -370,7 +370,7 @@ class Shopware_Plugins_Frontend_MoptPaymentPayone_Bootstrap extends Shopware_Com
         $container = Shopware()->Container();
 
         $subscribers = array(
-            new \Shopware\Plugins\MoptPaymentPayone\Subscribers\Resource(),
+            new \Shopware\Plugins\MoptPaymentPayone\Subscribers\PayoneResource(),
             new \Shopware\Plugins\MoptPaymentPayone\Subscribers\ControllerPath($this->Path()),
             new \Shopware\Plugins\MoptPaymentPayone\Subscribers\AddressCheck($container),
             new \Shopware\Plugins\MoptPaymentPayone\Subscribers\EMail($container),

--- a/Frontend/MoptPaymentPayone/Subscribers/PayoneResource.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/PayoneResource.php
@@ -4,7 +4,7 @@ namespace Shopware\Plugins\MoptPaymentPayone\Subscribers;
 
 use Enlight\Event\SubscriberInterface;
 
-class Resource implements SubscriberInterface
+class PayoneResource implements SubscriberInterface
 {
 
     /**


### PR DESCRIPTION
‘resource’ is a soft reserved word as of PHP 7.
Therefore this class needed to be refactored.