### PR TITLE
Remove unneccessary VAT ID parameter from Payolution Debit

### DIFF
--- a/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
+++ b/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
@@ -191,7 +191,6 @@ class Mopt_PayoneParamBuilder
         if ($paymentName == "mopt_payone__fin_payolution_invoice" || $paymentName == "mopt_payone__fin_payolution_debitnote") {
             if ($order->getBilling()->getCompany()) {
                 $params['payolution_b2b'] = true;
-                $params['vatid'] = $order->getBilling()->getUstid();
             }
         }
         


### PR DESCRIPTION
This is causing Exceptions when trying to debit a Payolution B2B order (internal reference TPI-1663)