### PR TITLE
Store the transaction ID together with clearing data (SW-67)

### DIFF
--- a/Frontend/MoptPaymentPayone/Components/Classes/PayonePaymentHelper.php
+++ b/Frontend/MoptPaymentPayone/Components/Classes/PayonePaymentHelper.php
@@ -132,6 +132,10 @@ class Mopt_PayonePaymentHelper
     {
         $responseData = $response->toArray();
 
+        if ($responseData['txid']) {
+            $responseData['clearing_txid'] = $responseData['txid'];
+        }
+
         foreach ($responseData as $key => $value) {
             if (strpos($key, 'clearing_') === false) {
                 unset($responseData[$key]);


### PR DESCRIPTION
The usual way to read values from the Shopware order atrributes array unfortunately is broken. Therefore shop admins could access this value only in a Shopware owned variable that was not documented by PAYONE. Now the value ‘txid’ from API responses will also be stored with the key ‘clearing_txid’ in the clearing data array for easier access in mail templates:

`{$additional.moptPayoneClearingData.clearing_txid}`