### PR TITLE
Fix payments for non-registered accounts

### DIFF
--- a/Frontend/MoptPaymentPayone/Subscribers/Payment.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/Payment.php
@@ -196,6 +196,7 @@ class Payment implements SubscriberInterface
 
             if ($config['consumerscoreActive'] && $config['consumerscoreCheckMoment'] == 1) {
                 //check if consumerscore is still valid or needs to be checked
+                $checkDate = new \DateTime($userData['mopt_payone_consumerscore_date']);
                 if (!$moptPayoneMain->getHelper()->isConsumerScoreCheckValid($config['consumerscoreLifetime'], $checkDate)) {
                     // add flag and data to session
                     $session->moptConsumerScoreCheckNeedsUserAgreement = true;

--- a/Frontend/MoptPaymentPayone/Subscribers/Payment.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/Payment.php
@@ -64,7 +64,7 @@ class Payment implements SubscriberInterface
         $post['mopt_payone__klarna_Day'] = $postData['mopt_payone__klarna_Day'];
 
         $paymentName = $returnValues['paymentData']['name'];
-        $paymentId = $postData['register']['payment'];
+        $paymentId = $postData['payment'] ? $postData['payment'] : $postData['register']['payment'];
         $moptPayoneMain = $this->container->get('MoptPayoneMain');
         $config = $moptPayoneMain->getPayoneConfig($paymentId);
         $session = Shopware()->Session();
@@ -86,7 +86,7 @@ class Payment implements SubscriberInterface
         }
 
         //@TODO check if still used
-        if ($postData['register']['payment'] === 'mopt_payone_creditcard') {
+        if ($postData['register'] && $postData['register']['payment'] === 'mopt_payone_creditcard') {
             $paymentName = $postData['register']['payment'];
         }
 
@@ -96,7 +96,7 @@ class Payment implements SubscriberInterface
         if (isset($paymentData['formData']['mopt_save_birthday_and_phone']) && $paymentData['formData']['mopt_save_birthday_and_phone']) {
             $moptPayoneMain->getPaymentHelper()->moptUpdateUserInformation($userId, $paymentData);
         }
-        
+
         if (isset($paymentData['formData']['mopt_save_birthday']) && $paymentData['formData']['mopt_save_birthday']) {
             $moptPayoneMain->getPaymentHelper()->moptUpdateUserInformation($userId, $paymentData);
         }
@@ -196,7 +196,6 @@ class Payment implements SubscriberInterface
 
             if ($config['consumerscoreActive'] && $config['consumerscoreCheckMoment'] == 1) {
                 //check if consumerscore is still valid or needs to be checked
-                $checkDate = new \DateTime($userData['mopt_payone_consumerscore_date']);
                 if (!$moptPayoneMain->getHelper()->isConsumerScoreCheckValid($config['consumerscoreLifetime'], $checkDate)) {
                     // add flag and data to session
                     $session->moptConsumerScoreCheckNeedsUserAgreement = true;


### PR DESCRIPTION
The plugin didn't save the payment data into the database. After digging deeper, we found out, that the wrong POST parameters were looked at (register[payment] instead of payment).
This is probably because, we disabled account registration on our checkout.