### PR TITLE
fix error code 1610 (Article list incomplete or faulty)

### DIFF
--- a/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
+++ b/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
@@ -1232,9 +1232,9 @@ class Mopt_PayoneParamBuilder
 
             $params['id'] = $article['ordernumber']; //article number
             if ($taxFree) {
-                $params['pr'] = $article['priceNumeric']; //price
+                $params['pr'] = round($article['netprice'], 2); //netto price
             } else {
-                $params['pr'] = round($article['netprice'] * (1 + ($article['tax_rate'] / 100)), 2); //price
+                $params['pr'] = round($article['priceNumeric'], 2); //brutto price
             }
             $params['no'] = $article['quantity']; // ordered quantity
             $params['de'] = substr($article['articlename'], 0, 100); // description


### PR DESCRIPTION
Dieser PR fixt den Fehlercode 1610 (Article list incomplete or faulty) beim Absetzen einer Bestellung mit Ratepay. Dieser kommt zu Stande, wenn der Betrag der einzelnen Positionen nicht mit dem Gesamtbetrag übereinstimmt. Dies rührt von einem Rundungsfehlers beim Berechnen des Positionspreises her.