### PR TITLE
use ordernumber in ParamBuilder

### DIFF
--- a/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
+++ b/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
@@ -1230,7 +1230,7 @@ class Mopt_PayoneParamBuilder
         foreach ($basket['content'] as $article) {
             $params = array();
 
-            $params['id'] = $article['ordernumber']; //article number
+            $params['id'] = substr($article['ordernumber'], 0, 32); //article number
             if ($taxFree) {
                 $params['pr'] = $article['priceNumeric']; //price
             } else {
@@ -1243,11 +1243,9 @@ class Mopt_PayoneParamBuilder
             $params['it'] = Payone_Api_Enum_InvoicingItemType::GOODS; //item type
             if ($article['modus'] == 2) {
                 $params['it'] = Payone_Api_Enum_InvoicingItemType::VOUCHER;
-                $params['id'] = substr($article['articlename'], 0, 32);
             }
             if ($article['modus'] == 4) {
                 $params['it'] = Payone_Api_Enum_InvoicingItemType::HANDLING;
-                $params['id'] = substr($article['articlename'], 0, 32);
             }
             $items[] = $params;
         }

--- a/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
+++ b/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
@@ -1230,7 +1230,7 @@ class Mopt_PayoneParamBuilder
         foreach ($basket['content'] as $article) {
             $params = array();
 
-            $params['id'] = substr($article['ordernumber'], 0, 32); //article number
+            $params['id'] = substr($article['ordernumber'] ?: $article['articlename'], 0, 32); //article number
             if ($taxFree) {
                 $params['pr'] = $article['priceNumeric']; //price
             } else {


### PR DESCRIPTION
Auch Gutscheine und Zuschläge haben eine Bestellnummer. Diese wird hier verwendet. Außerdem wird die Bestellnummer für normale Artikel ebenfalls in der Länge beschränkt um Fehlercode 1611 zu verhindern.