### PR TITLE
fix long shipping names in param builder

### DIFF
--- a/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
+++ b/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
@@ -1255,7 +1255,7 @@ class Mopt_PayoneParamBuilder
         //add shipment as position
         if ($shipment) {
             $params = array();
-            $params['id'] = substr($shipment['name'], 0, 100); //article number
+            $params['id'] = substr('ship' . $shipment['id'], 0, 32); //shipping id
             if ($taxFree) {
                 $params['pr'] = $basket['sShippingcosts'];
             } else {


### PR DESCRIPTION
Behebt zu langen ID Parameter wenn der Name der Versandart sehr lang ist (Fehlercode 1611).