### PR TITLE
hotfix for returned object instead of array

### DIFF
--- a/Frontend/MoptPaymentPayone/Components/Classes/PayoneMain.php
+++ b/Frontend/MoptPaymentPayone/Components/Classes/PayoneMain.php
@@ -97,8 +97,8 @@ class Mopt_PayoneMain
         $data       = $repository->getConfigByPaymentId($paymentId, $asArray);
 
         if ($data === null) {
-            $data = new Shopware\CustomModels\MoptPayoneConfig\MoptPayoneConfig();
-            $data->setPaymentId($paymentId);
+            $data = array();
+            $data['paymentId'] = $paymentId;
         }
 
         return $this->payoneConfig[$paymentId] = $data;


### PR DESCRIPTION
We got a fatal error in some cases on a staging system:
PHP Fatal error: Uncaught Error: Cannot use object of type Shopware\CustomModels\MoptPayoneConfig\MoptPayoneConfig as array in ../engine/Shopware/Plugins/Community/Frontend/MoptPaymentPayone/Components/Classes/PayonePaymentHelper.php:1303

=> The Fallback in this function creates an Object and returns it. The normal process returns an array