### PR TITLE
SW-186: Fatal error undefined customer getBilling() & getShipping() fix

### DIFF
--- a/Frontend/MoptPaymentPayone/Subscribers/AddressCheck.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/AddressCheck.php
@@ -878,12 +878,12 @@ class AddressCheck implements SubscriberInterface
             $userAttribute->setMoptPayoneConsumerscoreDate(0);
             Shopware()->Models()->persist($userAttribute);
             Shopware()->Models()->flush();
-            $billing = $user->getBilling();
+            $billing = $user->getDefaultBillingAddress();
             $billingAttribute = $moptPayoneMain->getHelper()->getOrCreateBillingAttribute($billing);
             $billingAttribute->setMoptPayoneAddresscheckDate(0);
             Shopware()->Models()->persist($billingAttribute);
             Shopware()->Models()->flush();
-            $shipping = $user->getShipping();
+            $shipping = $user->getDefaultShippingAddress();
             $shippingAttribute = $moptPayoneMain->getHelper()->getOrCreateShippingAttribute($shipping);
             $shippingAttribute->setMoptPayoneAddresscheckDate(0);
             Shopware()->Models()->persist($shippingAttribute);

--- a/Frontend/MoptPaymentPayone/Subscribers/AddressCheck.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/AddressCheck.php
@@ -878,12 +878,17 @@ class AddressCheck implements SubscriberInterface
             $userAttribute->setMoptPayoneConsumerscoreDate(0);
             Shopware()->Models()->persist($userAttribute);
             Shopware()->Models()->flush();
-            $billing = $user->getDefaultBillingAddress();
+            if (\Shopware::VERSION === '___VERSION___' || version_compare(\Shopware::VERSION, '5.2.0', '>=')) {
+                $billing = $user->getDefaultBillingAddress();
+                $shipping = $user->getDefaultShippingAddress();
+            } else {
+                $billing = $user->getBilling();
+                $shipping = $user->getShipping();
+            }
             $billingAttribute = $moptPayoneMain->getHelper()->getOrCreateBillingAttribute($billing);
             $billingAttribute->setMoptPayoneAddresscheckDate(0);
             Shopware()->Models()->persist($billingAttribute);
             Shopware()->Models()->flush();
-            $shipping = $user->getDefaultShippingAddress();
             $shippingAttribute = $moptPayoneMain->getHelper()->getOrCreateShippingAttribute($shipping);
             $shippingAttribute->setMoptPayoneAddresscheckDate(0);
             Shopware()->Models()->persist($shippingAttribute);


### PR DESCRIPTION
This seems required to fix the following two error in 5.5.1 please refer https://developers.shopware.com/developers-guide/shopware-5-upgrade-guide-for-developers/#address-management as Shopware\Models\Customer\Billing [getShipping()] and \Shopware\Models\Customer\Shipping [getShipping()] are removed now:

`PHP Fatal error:  Uncaught Error: Call to undefined method Shopware\\Models\\Customer\\Customer::getShipping() in /home/vagrant/www/shopware/engine/Shopware/Plugins/Community/Frontend/MoptPaymentPayone/Subscribers/AddressCheck.php:886`

and 

`PHP Fatal error:  Uncaught Error: Call to undefined method Shopware\\Models\\Customer\\Customer::getBilling() in /home/vagrant/www/shopware/engine/Shopware/Plugins/Community/Frontend/MoptPaymentPayone/Subscribers/AddressCheck.php:881`