### PR TITLE
Added Events at Payment Grouping

### DIFF
--- a/Frontend/MoptPaymentPayone/Subscribers/Payment.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/Payment.php
@@ -254,7 +254,7 @@ class Payment implements SubscriberInterface
             return;
         }
 		
-		$this->container->get('events')->notify(
+        $this->container->get('events')->notify(
             'MoptPaymentPayone_Subscriber_Payment_paymentGrouped',
             [
                 'payments' => $paymentMeansWithGroupedCreditcard
@@ -316,13 +316,12 @@ class Payment implements SubscriberInterface
             $subject->View()->sPayments = $groupedPaymentMeans;
         }
 		
-		$this->container->get('events')->notify(
+        $this->container->get('events')->notify(
             'MoptPaymentPayone_Subscriber_Payment_paymentGrouped',
             [
-                'payments' => $groupedPaymentMeans
+                'payments' => $paymentMeansWithGroupedCreditcard
             ]
         );
-		
     }
 
     /**

--- a/Frontend/MoptPaymentPayone/Subscribers/Payment.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/Payment.php
@@ -252,14 +252,14 @@ class Payment implements SubscriberInterface
 
         if (!$paymentMeansWithGroupedCreditcard) {
             return;
-        }else{
-			$this->container->get('events')->notify(
-				'MoptPaymentPayone_Subscriber_Payment_onGetPaymentMeans_paymentsGrouped',
-				[
-					'groupedPaymentMeans' => $paymentMeansWithGroupedCreditcard
-				]
-			);
-		}
+        } else {
+            $this->container->get('events')->notify(
+                'MoptPaymentPayone_Subscriber_Payment_onGetPaymentMeans_paymentsGrouped',
+                [
+                    'groupedPaymentMeans' => $paymentMeansWithGroupedCreditcard
+                ]
+            );
+        }
 		
         $arguments->setReturn($paymentMeansWithGroupedCreditcard);
     }

--- a/Frontend/MoptPaymentPayone/Subscribers/Payment.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/Payment.php
@@ -252,14 +252,14 @@ class Payment implements SubscriberInterface
 
         if (!$paymentMeansWithGroupedCreditcard) {
             return;
-        }
-		
-        $this->container->get('events')->notify(
-            'MoptPaymentPayone_Subscriber_Payment_paymentGrouped',
-            [
-                'payments' => $paymentMeansWithGroupedCreditcard
-            ]
-        );
+        }else{
+			$this->container->get('events')->notify(
+				'MoptPaymentPayone_Subscriber_Payment_onGetPaymentMeans_paymentsGrouped',
+				[
+					'groupedPaymentMeans' => $paymentMeansWithGroupedCreditcard
+				]
+			);
+		}
 		
         $arguments->setReturn($paymentMeansWithGroupedCreditcard);
     }
@@ -314,14 +314,13 @@ class Payment implements SubscriberInterface
         $groupedPaymentMeans = $moptPayoneMain->getPaymentHelper()->groupCreditcards($subject->View()->sPayments);
         if ($groupedPaymentMeans) {
             $subject->View()->sPayments = $groupedPaymentMeans;
+            $this->container->get('events')->notify(
+                'MoptPaymentPayone_Subscriber_Payment_onShippingPaymentAction_paymentsGrouped',
+                [
+                    'groupedPaymentMeans' => $paymentMeansWithGroupedCreditcard
+                ]
+            );
         }
-		
-        $this->container->get('events')->notify(
-            'MoptPaymentPayone_Subscriber_Payment_paymentGrouped',
-            [
-                'payments' => $paymentMeansWithGroupedCreditcard
-            ]
-        );
     }
 
     /**

--- a/Frontend/MoptPaymentPayone/Subscribers/Payment.php
+++ b/Frontend/MoptPaymentPayone/Subscribers/Payment.php
@@ -253,7 +253,14 @@ class Payment implements SubscriberInterface
         if (!$paymentMeansWithGroupedCreditcard) {
             return;
         }
-
+		
+		$this->container->get('events')->notify(
+            'MoptPaymentPayone_Subscriber_Payment_paymentGrouped',
+            [
+                'payments' => $paymentMeansWithGroupedCreditcard
+            ]
+        );
+		
         $arguments->setReturn($paymentMeansWithGroupedCreditcard);
     }
 
@@ -308,6 +315,14 @@ class Payment implements SubscriberInterface
         if ($groupedPaymentMeans) {
             $subject->View()->sPayments = $groupedPaymentMeans;
         }
+		
+		$this->container->get('events')->notify(
+            'MoptPaymentPayone_Subscriber_Payment_paymentGrouped',
+            [
+                'payments' => $groupedPaymentMeans
+            ]
+        );
+		
     }
 
     /**


### PR DESCRIPTION
These Events will be fired when the plugin has grouped the Payment Methods so other Plugins can subscribe to it and retrieve the new list.

Fixes #296 