### PR TITLE
Make shortening of article description multibyte-safe

### DIFF
--- a/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
+++ b/Frontend/MoptPaymentPayone/Components/Classes/PayoneParamBuilder.php
@@ -1259,7 +1259,7 @@ class Mopt_PayoneParamBuilder
                 $params['pr'] = round($article['priceNumeric'], 2); //brutto price
             }
             $params['no'] = $article['quantity']; // ordered quantity
-            $params['de'] = substr($article['articlename'], 0, 100); // description
+            $params['de'] = mb_substr($article['articlename'], 0, 100); // description
             $params['va'] = $taxFree ? 0 : number_format($article['tax_rate'], 0, '.', ''); // vat
             $params['va'] = round($params['va'] * 100);
             $params['it'] = Payone_Api_Enum_InvoicingItemType::GOODS; //item type


### PR DESCRIPTION
Fixes #308 

Given a multi byte string article description (for instance containing `ß`) shortening using `substr()` won't work and lead to errors at the Payone API.