### PR TITLE
improved ssl detection in templates

### DIFF
--- a/Frontend/MoptPaymentPayone/Views/frontend/checkout/ajax_cart_amazon.tpl
+++ b/Frontend/MoptPaymentPayone/Views/frontend/checkout/ajax_cart_amazon.tpl
@@ -9,7 +9,7 @@
     {include file="frontend/checkout/script-amazonpay.tpl"}
 
     <script>
-    {if $smarty.server.REQUEST_SCHEME === 'https'}
+    {if $smarty.server.REQUEST_SCHEME === 'https' || $smarty.server.HTTPS === 'on' || $smarty.server.HTTP_HTTPS === 'on' || $smarty.server.HTTP_X_FORWARDED_PROTO === 'https'}
         window.onAmazonPaymentsReady = function () {
         offPaymentsWrapper('LoginWithAmazonAjaxCart', true, false);
         };

--- a/Frontend/MoptPaymentPayone/Views/frontend/checkout/mopt_cart_amazon.tpl
+++ b/Frontend/MoptPaymentPayone/Views/frontend/checkout/mopt_cart_amazon.tpl
@@ -11,7 +11,7 @@
 {include file="frontend/checkout/script-amazonpay.tpl"}
 
 <script>
-{if $smarty.server.REQUEST_SCHEME === 'https'}
+{if $smarty.server.REQUEST_SCHEME === 'https' || $smarty.server.HTTPS === 'on' || $smarty.server.HTTP_HTTPS === 'on' || $smarty.server.HTTP_X_FORWARDED_PROTO === 'https'}
     window.onAmazonPaymentsReady = function () {
         offPaymentsWrapper('LoginWithAmazon', true, false);
         offPaymentsWrapper('LoginWithAmazonBottom', true, false);


### PR DESCRIPTION
Extend if-clause for detection of ssl to be more flexible in distributed environments using loadbalancers.

Has been tested with one of our customers and works as expected.

Fixes #333 