### PR TITLE
SW-353: added successurl param for connection test

### DIFF
--- a/Frontend/MoptPaymentPayone/Components/Payone/Api/Service/Payment/Preauthorize.php
+++ b/Frontend/MoptPaymentPayone/Components/Payone/Api/Service/Payment/Preauthorize.php
@@ -86,8 +86,16 @@ class Payone_Api_Service_Payment_Preauthorize extends Payone_Api_Service_Payment
 
             $this->protocol($request, $response);
         } catch (Exception $e) {
-            $this->protocolException($e, $request);
-            throw $e;
+            // @Shopware() kernel is unavailable when triggering preauthorize from FcPayone custom Backend
+            // handle all other exceptions normally
+            if (get_class($e) !== 'Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException'  ) {
+                $this->protocolException($e, $request);
+                throw $e;
+            } else {
+                $responseRaw = $this->getAdapter()->request($requestParams);
+                $response = $this->getMapperResponse()->map($responseRaw);
+                $this->protocol($request, $response);
+            }
         }
 
         return $response;

--- a/Frontend/MoptPaymentPayone/Controllers/Backend/FcPayone.php
+++ b/Frontend/MoptPaymentPayone/Controllers/Backend/FcPayone.php
@@ -217,6 +217,7 @@ class Shopware_Controllers_Backend_FcPayone extends Enlight_Controller_Action im
 
         $request->setPersonalData($pData);
         $request->setPayment($paymentData);
+        $request->setSuccessurl('https://payone.com');
         $request->setMode('test');
 
         $this->logging->lwrite('<span style="color: yellow;">teste Request Authorisierung im Modus Test mit Zahlart Kreditkarte (Visa)</span>');
@@ -275,6 +276,7 @@ class Shopware_Controllers_Backend_FcPayone extends Enlight_Controller_Action im
         $request->setPayment($paymentData);
 
         $paymentData->setEcommercemode('internet');
+        $request->setSuccessurl('https://payone.com');
         $request->setMode('test');
 
         $this->logging->lwrite('<span style="color: yellow;">teste Request Authorisierung im Modus Test mit Zahlart Kreditkarte (Mastercard)</span>');


### PR DESCRIPTION
* fixed issue when using preauthorize from fcPayone backend controller