### PR TITLE
Dangerous JS Functio eval() -  PCI DSS ASV Scan issue

### DIFF
--- a/Frontend/MoptPaymentPayone/Views/frontend/_resources/javascript/mopt_payment.js
+++ b/Frontend/MoptPaymentPayone/Views/frontend/_resources/javascript/mopt_payment.js
@@ -484,8 +484,7 @@ function moptPaymentReady() {
             if (me.opts.moptCreditcardConfig.show_errors === '1') {
                 config.error = "errorOutput";
             }
-            config.language = eval('Payone.ClientApi.Language.' + me.opts.moptPayoneParamsLanguage);
-
+            config.language = Payone.ClientApi.Language[me.opts.moptPayoneParamsLanguage] || Payone.ClientApi.Language.en;
 
             if (me.opts.moptCreditcardConfig.cardno_custom_style === '0') {
                 config.fields.cardpan.style = me.opts.moptCreditcardConfig.cardno_input_css;


### PR DESCRIPTION
Replace potentially dangerous eval() call. Severity rating medium (CVSS Score 4.5). Creates issues with PCI DSS ASV scans.